### PR TITLE
Experimental java 18 support

### DIFF
--- a/src/main/java/net/minecraftforge/launch/loader/ForgeLaunchWrapperClassLoader.java
+++ b/src/main/java/net/minecraftforge/launch/loader/ForgeLaunchWrapperClassLoader.java
@@ -195,9 +195,11 @@ public class ForgeLaunchWrapperClassLoader extends URLClassLoader {
         Class<?> invokeDynamicTransformer = Class.forName("net.minecraftforge.patching.InvokeDynamicTransformer", true, this);
         Class<?> classReaderTransformer = Class.forName("net.minecraftforge.patching.ClassReaderTransformer", true, this);
         Class<?> mixinConstantTransformer = Class.forName("net.minecraftforge.patching.MixinConstantUtilNPE", true, this);
+        Class<?> mixinDoubleTransformer = Class.forName("net.minecraftforge.patching.MixinDoubleMadness", true, this);
         addTransformer((ForgeTransformer) mixinServiceLaunchWrapperTransformer.newInstance());
         addTransformer((ForgeTransformer) invokeDynamicTransformer.newInstance());
         addTransformer((ForgeTransformer) classReaderTransformer.newInstance());
         addTransformer((ForgeTransformer) mixinConstantTransformer.newInstance());
+        addTransformer((ForgeTransformer) mixinDoubleTransformer.newInstance());
     }
 }

--- a/src/main/java/net/minecraftforge/launch/loader/ForgeLaunchWrapperClassLoader.java
+++ b/src/main/java/net/minecraftforge/launch/loader/ForgeLaunchWrapperClassLoader.java
@@ -194,8 +194,10 @@ public class ForgeLaunchWrapperClassLoader extends URLClassLoader {
         Class<?> mixinServiceLaunchWrapperTransformer = Class.forName("net.minecraftforge.patching.MixinServiceLaunchWrapperTransformer", true, this);
         Class<?> invokeDynamicTransformer = Class.forName("net.minecraftforge.patching.InvokeDynamicTransformer", true, this);
         Class<?> classReaderTransformer = Class.forName("net.minecraftforge.patching.ClassReaderTransformer", true, this);
+        Class<?> mixinConstantTransformer = Class.forName("net.minecraftforge.patching.MixinConstantUtilNPE", true, this);
         addTransformer((ForgeTransformer) mixinServiceLaunchWrapperTransformer.newInstance());
         addTransformer((ForgeTransformer) invokeDynamicTransformer.newInstance());
         addTransformer((ForgeTransformer) classReaderTransformer.newInstance());
+        addTransformer((ForgeTransformer) mixinConstantTransformer.newInstance());
     }
 }

--- a/src/main/java/net/minecraftforge/patching/MixinConstantUtilNPE.java
+++ b/src/main/java/net/minecraftforge/patching/MixinConstantUtilNPE.java
@@ -22,17 +22,11 @@ public class MixinConstantUtilNPE implements ForgeTransformer {
             reader.accept(classNode, ClassReader.EXPAND_FRAMES);
 
             for (MethodNode methodNode : classNode.methods) {
-                System.out.println(methodNode.name);
                 if (methodNode.name.equals("<clinit>")) {
-                    System.out.println("we made it1");
                     InsnList list = methodNode.instructions;
-                    System.out.println("we made it2");
                     ListIterator<AbstractInsnNode> nodeIterator = list.iterator();
-                    System.out.println("we made it3");
-                    System.out.println(list.size());
                     while (nodeIterator.hasNext()) {
                         AbstractInsnNode insnNode = nodeIterator.next();
-                        System.out.println(insnToString(insnNode));
 
                         if (insnNode instanceof LdcInsnNode && ((LdcInsnNode) insnNode).cst instanceof Type) {
                             if (((Type)((LdcInsnNode) insnNode).cst).getInternalName().equals("org/spongepowered/asm/mixin/Mixin")) {
@@ -45,11 +39,6 @@ public class MixinConstantUtilNPE implements ForgeTransformer {
                                 break;
                             }
                         }
-                        System.out.println(insnToString(insnNode));
-                    }
-                    System.out.println(list.size());
-                    for(int i = 0; i< list.size(); i++){
-                        System.out.print(insnToString(list.get(i)));
                     }
                 }
             }
@@ -62,15 +51,4 @@ public class MixinConstantUtilNPE implements ForgeTransformer {
 
         return bytes;
     }
-
-    public static String insnToString(AbstractInsnNode insn){
-        insn.accept(mp);
-        StringWriter sw = new StringWriter();
-        printer.print(new PrintWriter(sw));
-        printer.getText().clear();
-        return sw.toString();
-    }
-
-    private static Printer printer = new Textifier();
-    private static TraceMethodVisitor mp = new TraceMethodVisitor(printer);
 }

--- a/src/main/java/net/minecraftforge/patching/MixinConstantUtilNPE.java
+++ b/src/main/java/net/minecraftforge/patching/MixinConstantUtilNPE.java
@@ -1,0 +1,76 @@
+package net.minecraftforge.patching;
+
+import net.minecraftforge.launch.loader.transformer.ForgeTransformer;
+import java.io.InputStream;
+import java.io.FileInputStream;
+import java.io.StringWriter;
+import java.io.PrintWriter;
+import java.util.List;
+import org.objectweb.asm.*;
+import org.objectweb.asm.tree.*;
+import org.objectweb.asm.util.*;
+
+import java.util.ListIterator;
+
+public class MixinConstantUtilNPE implements ForgeTransformer {
+    @Override
+    public byte[] transform(String name, byte[] bytes) {
+        if (name.equals("org.spongepowered.asm.util.Constants")) {
+            ClassReader reader = new ClassReader(bytes);
+            ClassNode classNode = new ClassNode();
+
+            reader.accept(classNode, ClassReader.EXPAND_FRAMES);
+
+            for (MethodNode methodNode : classNode.methods) {
+                System.out.println(methodNode.name);
+                if (methodNode.name.equals("<clinit>")) {
+                    System.out.println("we made it1");
+                    InsnList list = methodNode.instructions;
+                    System.out.println("we made it2");
+                    ListIterator<AbstractInsnNode> nodeIterator = list.iterator();
+                    System.out.println("we made it3");
+                    System.out.println(list.size());
+                    while (nodeIterator.hasNext()) {
+                        AbstractInsnNode insnNode = nodeIterator.next();
+                        System.out.println(insnToString(insnNode));
+
+                        if (insnNode instanceof LdcInsnNode && ((LdcInsnNode) insnNode).cst instanceof Type) {
+                            if (((Type)((LdcInsnNode) insnNode).cst).getInternalName().equals("org/spongepowered/asm/mixin/Mixin")) {
+                                AbstractInsnNode invokePackage = insnNode.getNext();
+                                AbstractInsnNode invokeName = invokePackage.getNext();
+
+                                list.set(insnNode, new LdcInsnNode("org.spongepowered.asm.mixin.Mixin"));
+                                list.remove(invokePackage);
+                                list.remove(invokeName);
+                                break;
+                            }
+                        }
+                        System.out.println(insnToString(insnNode));
+                    }
+                    System.out.println(list.size());
+                    for(int i = 0; i< list.size(); i++){
+                        System.out.print(insnToString(list.get(i)));
+                    }
+                }
+            }
+
+            ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+            classNode.accept(writer);
+
+            return writer.toByteArray();
+        }
+
+        return bytes;
+    }
+
+    public static String insnToString(AbstractInsnNode insn){
+        insn.accept(mp);
+        StringWriter sw = new StringWriter();
+        printer.print(new PrintWriter(sw));
+        printer.getText().clear();
+        return sw.toString();
+    }
+
+    private static Printer printer = new Textifier();
+    private static TraceMethodVisitor mp = new TraceMethodVisitor(printer);
+}

--- a/src/main/java/net/minecraftforge/patching/MixinDoubleMadness.java
+++ b/src/main/java/net/minecraftforge/patching/MixinDoubleMadness.java
@@ -1,0 +1,68 @@
+package net.minecraftforge.patching;
+
+import net.minecraftforge.launch.loader.transformer.ForgeTransformer;
+import java.io.InputStream;
+import java.io.FileInputStream;
+import java.io.StringWriter;
+import java.io.PrintWriter;
+import java.util.List;
+import org.objectweb.asm.*;
+import org.objectweb.asm.tree.*;
+import org.objectweb.asm.util.*;
+
+import java.util.ListIterator;
+
+public class MixinDoubleMadness implements ForgeTransformer {
+    @Override
+    public byte[] transform(String name, byte[] bytes) {
+        if (name.equals("org.spongepowered.asm.util.JavaVersion")) {
+            ClassReader reader = new ClassReader(bytes);
+            ClassNode classNode = new ClassNode();
+
+            reader.accept(classNode, ClassReader.EXPAND_FRAMES);
+
+            for (MethodNode methodNode : classNode.methods) {
+                System.out.println(methodNode.name);
+                if (methodNode.name.equals("resolveCurrentVersion")) {
+                    InsnList list = methodNode.instructions;
+                    ListIterator<AbstractInsnNode> nodeIterator = list.iterator();
+                    while (nodeIterator.hasNext()) {
+                        AbstractInsnNode insnNode = nodeIterator.next();
+                        System.out.println(insnToString(insnNode));
+
+                        if (insnNode instanceof LdcInsnNode && ((LdcInsnNode) insnNode).cst instanceof String) {
+                            if (((String)((LdcInsnNode) insnNode).cst).equals("[0-9]+\\.[0-9]+")) {
+
+                                list.set(insnNode, new LdcInsnNode("^.?.?(?<=\\.|^)([0-9]+)"));
+                                break;
+                            }
+                        }
+                        System.out.println(insnToString(insnNode));
+                    }
+                    System.out.println(list.size());
+                    for(int i = 0; i< list.size(); i++){
+                        System.out.print(insnToString(list.get(i)));
+                    }
+                }
+            }
+
+            ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+            classNode.accept(writer);
+
+            return writer.toByteArray();
+        }
+
+        return bytes;
+    }
+
+    public static String insnToString(AbstractInsnNode insn){
+        insn.accept(mp);
+        StringWriter sw = new StringWriter();
+        printer.print(new PrintWriter(sw));
+        printer.getText().clear();
+        return sw.toString();
+    }
+
+    private static Printer printer = new Textifier();
+    private static TraceMethodVisitor mp = new TraceMethodVisitor(printer);
+}

--- a/src/main/java/net/minecraftforge/patching/MixinDoubleMadness.java
+++ b/src/main/java/net/minecraftforge/patching/MixinDoubleMadness.java
@@ -22,13 +22,11 @@ public class MixinDoubleMadness implements ForgeTransformer {
             reader.accept(classNode, ClassReader.EXPAND_FRAMES);
 
             for (MethodNode methodNode : classNode.methods) {
-                System.out.println(methodNode.name);
                 if (methodNode.name.equals("resolveCurrentVersion")) {
                     InsnList list = methodNode.instructions;
                     ListIterator<AbstractInsnNode> nodeIterator = list.iterator();
                     while (nodeIterator.hasNext()) {
                         AbstractInsnNode insnNode = nodeIterator.next();
-                        System.out.println(insnToString(insnNode));
 
                         if (insnNode instanceof LdcInsnNode && ((LdcInsnNode) insnNode).cst instanceof String) {
                             if (((String)((LdcInsnNode) insnNode).cst).equals("[0-9]+\\.[0-9]+")) {
@@ -37,11 +35,6 @@ public class MixinDoubleMadness implements ForgeTransformer {
                                 break;
                             }
                         }
-                        System.out.println(insnToString(insnNode));
-                    }
-                    System.out.println(list.size());
-                    for(int i = 0; i< list.size(); i++){
-                        System.out.print(insnToString(list.get(i)));
                     }
                 }
             }
@@ -54,15 +47,4 @@ public class MixinDoubleMadness implements ForgeTransformer {
 
         return bytes;
     }
-
-    public static String insnToString(AbstractInsnNode insn){
-        insn.accept(mp);
-        StringWriter sw = new StringWriter();
-        printer.print(new PrintWriter(sw));
-        printer.getText().clear();
-        return sw.toString();
-    }
-
-    private static Printer printer = new Textifier();
-    private static TraceMethodVisitor mp = new TraceMethodVisitor(printer);
 }


### PR DESCRIPTION
Add two transformers:
The first transformer is for modifying `Mixin.class.getPackage().getName()` to a constant value (`org.spongepowered.asm.mixin.Mixin`). According to the javadocs:
>  If the caller's ClassLoader instance is the bootstrap ClassLoader instance, which may be represented by null in some implementations, only packages corresponding to classes loaded by the bootstrap ClassLoader instance will be returned.
This causes an NPE because the classloader decided it wanted to, so we can easily just change it out for the constant value.

The second transformer is specifically for 18 (and any weird java version), as it changes the regex from `[0-9]+\.[0-9]+` to `^.?.?(?<=\.|^)([0-9]+)`.

These are both targeted at Mixins.